### PR TITLE
Switch docker image to use alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.10
+FROM golang:1.10-alpine
+
+RUN apk add git
 
 ENV DOCKER_VERSION "18.03.1-ce"
 RUN wget -q -P /tmp https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz \


### PR DESCRIPTION
Since the default debian based images contain a lot of CVEs and Clair is going nuts